### PR TITLE
fix: inject GA4 script during CI build (#483)

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -52,7 +52,6 @@ jobs:
           echo "Current directory contents after generation:"
           ls -la generated/resume/
 
-          # Inject GA4 script into all generated HTML files
           for html_file in generated/resume/*.html; do
             sed -i '/<head>/a \  <script async src="https://www.googletagmanager.com/gtag/js?id=G-ES8HLN40E3"></script>\n  <script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag('\''js'\'', new Date());\n  gtag('\''config'\'', '\''G-ES8HLN40E3'\'');\n  </script>' "$html_file"
           done

--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -54,7 +54,7 @@ jobs:
 
           # Inject GA4 script into all generated HTML files
           for html_file in generated/resume/*.html; do
-            sed -i '/<head>/a \  <script async src="https://www.googletagmanager.com/gtag/js?id=${{ secrets.GA4_TRACKING_ID }}"></script>\n  <script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag('\''js'\'', new Date());\n  gtag('\''config'\'', '\''${{ secrets.GA4_TRACKING_ID }}'\'');\n  </script>' "$html_file"
+            sed -i '/<head>/a \  <script async src="https://www.googletagmanager.com/gtag/js?id=G-ES8HLN40E3"></script>\n  <script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag('\''js'\'', new Date());\n  gtag('\''config'\'', '\''G-ES8HLN40E3'\'');\n  </script>' "$html_file"
           done
 
           echo "Git status:"

--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -52,6 +52,11 @@ jobs:
           echo "Current directory contents after generation:"
           ls -la generated/resume/
 
+          # Inject GA4 script into all generated HTML files
+          for html_file in generated/resume/*.html; do
+            sed -i '/<head>/a \  <script async src="https://www.googletagmanager.com/gtag/js?id=${{ secrets.GA4_TRACKING_ID }}"></script>\n  <script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag('\''js'\'', new Date());\n  gtag('\''config'\'', '\''${{ secrets.GA4_TRACKING_ID }}'\'');\n  </script>' "$html_file"
+          done
+
           echo "Git status:"
           git status
 


### PR DESCRIPTION
Fixes #483

Changes:
- Inject GA4 tracking script (ID: G-ES8HLN40E3) during CI build process
- Add script injection step in .github/workflows/resume.yml
- Verified script injection works in all generated HTML files
- Confirmed PDF generation still works correctly (1 page for short resume)

Link to Devin run: https://app.devin.ai/sessions/ec73dbf0ab354d6eb12136a21d54110d