### PR TITLE
fix(resume): implement GitHub App token auth following example workflow

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -6,15 +6,23 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  RELEASE_APP_ID: 795363
+  RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+  PJ_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
 jobs:
   generate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ env.RELEASE_APP_ID }}
+          private-key: ${{ env.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
@@ -68,11 +76,11 @@ jobs:
           git add generated/
           git status
 
-      - name: Commit and push changes
-        if: github.ref == 'refs/heads/main'
+      - run: git config --global user.email "gh-actions"
+      - run: git config --global user.name "gh-actions"
+
+      - if: github.ref == 'refs/heads/main'
         run: |
-          git config --global user.email "gh-actions"
-          git config --global user.name "gh-actions"
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
fix(resume): implement GitHub App token auth following example workflow

This PR fixes #495 by implementing the GitHub App token authentication exactly as shown in the example workflow:

Changes:
- Added environment variables:
  - RELEASE_APP_ID: 795363
  - RELEASE_APP_PRIVATE_KEY
  - PJ_GITHUB_TOKEN
- Added actions/create-github-app-token@v1 step for token generation
- Updated checkout action to use the generated token
- Kept Node.js at v17
- Maintained git configuration and commit/push steps matching example exactly

Testing:
- [ ] CI checks must pass
- [ ] After merging, verify that the Resume workflow can successfully push to main

Link to Devin run: https://app.devin.ai/sessions/33d80bf0cbb74cf1b7eaeef289f95286
